### PR TITLE
Rebrand strawberry-themed UI to generic organic food

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Author: Muhammad-Tameem Mughal
 Last updated: Aug 15, 2025
 Last modified by: Muhammad-Tameem Mughal
 
-# StrawbChain Blockchain Overview
+# FoodTraceChain Blockchain Overview
 
 This repository implements an end-to-end food supply chain tracing system built on Hyperledger Fabric. The solution is composed of three major parts:
 

--- a/application/foodtrace-ledger-supply/index.html
+++ b/application/foodtrace-ledger-supply/index.html
@@ -9,11 +9,11 @@ Last modified by: Muhammad-Tameem Mughal
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StrawberryChain</title>
+    <title>FoodTraceChain</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 
-    <meta property="og:title" content="StrawberryChain" />
+    <meta property="og:title" content="FoodTraceChain" />
     <meta property="og:description" content="Lovable Generated Project" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />

--- a/application/foodtrace-ledger-supply/src/App.tsx
+++ b/application/foodtrace-ledger-supply/src/App.tsx
@@ -27,7 +27,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     );
   }
@@ -41,7 +41,7 @@ const AdminRoute = ({ children }: { children: React.ReactNode }) => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     );
   }

--- a/application/foodtrace-ledger-supply/src/components/AssignRoleForm.tsx
+++ b/application/foodtrace-ledger-supply/src/components/AssignRoleForm.tsx
@@ -50,7 +50,7 @@ const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ identities, onSuccess, 
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center space-x-2">
-          <UserPlus className="h-5 w-5 text-pink-600" />
+          <UserPlus className="h-5 w-5 text-green-600" />
           <span>Assign Role</span>
         </CardTitle>
         <CardDescription>Select an identity and role</CardDescription>
@@ -89,7 +89,7 @@ const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ identities, onSuccess, 
             <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
               <X className="h-4 w-4 mr-2" />Cancel
             </Button>
-            <Button type="submit" className="bg-pink-600 hover:bg-rose-700" disabled={loading}>
+            <Button type="submit" className="bg-green-600 hover:bg-emerald-700" disabled={loading}>
               {loading ? 'Assigning...' : 'Assign Role'}
             </Button>
           </div>

--- a/application/foodtrace-ledger-supply/src/components/Layout.tsx
+++ b/application/foodtrace-ledger-supply/src/components/Layout.tsx
@@ -64,18 +64,18 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-rose-50 via-pink-50 to-rose-100">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-green-100">
       {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-rose-200 sticky top-0 z-50">
+      <header className="bg-white/80 backdrop-blur-sm border-b border-green-200 sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center space-x-8">
               <Link to="/dashboard" className="flex items-center space-x-2">
-                <div className="h-8 w-8 bg-gradient-to-r from-pink-500 to-rose-600 rounded-lg flex items-center justify-center">
-                  <span className="text-white text-lg" role="img" aria-label="strawberry">🍓</span>
+              <div className="h-8 w-8 bg-gradient-to-r from-green-500 to-emerald-600 rounded-lg flex items-center justify-center">
+                  <span className="text-white text-lg" role="img" aria-label="leaf">🌱</span>
                 </div>
-                <span className="text-xl font-bold bg-gradient-to-r from-pink-600 to-rose-600 bg-clip-text text-transparent">
-                  StrawberryChain
+                <span className="text-xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
+                  FoodTraceChain
                 </span>
               </Link>
 
@@ -86,8 +86,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                     to={item.path}
                     className={`flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                       location.pathname === item.path
-                        ? 'bg-rose-100 text-rose-700'
-                        : 'text-gray-600 hover:text-pink-600 hover:bg-pink-50'
+                        ? 'bg-green-100 text-green-700'
+                        : 'text-gray-600 hover:text-green-600 hover:bg-green-50'
                     }`}
                   >
                     {item.icon}
@@ -98,13 +98,13 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             </div>
 
             <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-2 px-3 py-1 bg-white rounded-full border border-rose-200">
+            <div className="flex items-center space-x-2 px-3 py-1 bg-white rounded-full border border-green-200">
                 {getRoleIcon(user?.role || '')}
                 <span className="text-sm font-medium text-gray-700 capitalize">
                   {user?.role}
                 </span>
                 {user?.is_admin && (
-                  <span className="text-xs bg-rose-100 text-rose-700 px-2 py-1 rounded-full">
+                  <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full">
                     Admin
                   </span>
                 )}
@@ -113,7 +113,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 variant="outline"
                 size="sm"
                 onClick={handleLogout}
-                className="border-rose-200 text-rose-700 hover:bg-rose-50"
+                className="border-green-200 text-green-700 hover:bg-green-50"
               >
                 Logout
               </Button>

--- a/application/foodtrace-ledger-supply/src/components/MapPicker.tsx
+++ b/application/foodtrace-ledger-supply/src/components/MapPicker.tsx
@@ -59,7 +59,7 @@ const MapPicker: React.FC<MapPickerProps> = ({ latitude, longitude, onChange }) 
         <button
           type="button"
           onClick={handleSearch}
-          className="px-3 py-1 bg-pink-600 text-white rounded"
+          className="px-3 py-1 bg-green-600 text-white rounded"
         >
           Search
         </button>

--- a/application/foodtrace-ledger-supply/src/pages/AdminPanel.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/AdminPanel.tsx
@@ -133,7 +133,7 @@ const AdminPanel = () => {
     return (
       <Layout>
         <div className="flex items-center justify-center h-64">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
         </div>
       </Layout>
     );

--- a/application/foodtrace-ledger-supply/src/pages/AllShipments.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/AllShipments.tsx
@@ -142,7 +142,7 @@ const AllShipments = () => {
     return (
       <Layout>
         <div className="flex items-center justify-center h-64">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
         </div>
       </Layout>
     );

--- a/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/CreateShipment.tsx
@@ -86,16 +86,16 @@ const CreateShipment = () => {
 
     setFormData({
       shipmentId: "", // auto-generate for demo
-      productName: "Premium Organic Strawberries",
+      productName: "Premium Organic Produce",
       description:
-        "Freshly harvested, organically grown strawberries from raised beds. Cooled quickly for quality.",
+        "Freshly harvested, organically grown produce from mixed fields. Cooled quickly for quality.",
       quantity: "120.0", // as string from input
       unitOfMeasure: "kg",
-      farmerName: "Demo Berry Farms Ltd.",
+      farmerName: "Demo Organic Farms Ltd.",
       farmLocation: "Norfolk County, ON, Canada",
       farmLatitude: "42.8339",
       farmLongitude: "-80.3830",
-      cropType: "Strawberries (Albion)",
+      cropType: "Mixed Vegetables",
       plantingDate: formatDateForInput(planting),
       harvestDate: formatDateForInput(harvest),
       fertilizerUsed: "Organic compost blend, kelp meal",
@@ -107,7 +107,7 @@ const CreateShipment = () => {
       ),
       bufferZoneMeters: "25",
       destinationProcessorId: "DemoProcessor1",
-      certificationDocumentHash: "demoDocHash_organicStrawberries_abc123",
+      certificationDocumentHash: "demoDocHash_organicProduce_abc123",
     });
     toast({
       title: "Demo Data Loaded",

--- a/application/foodtrace-ledger-supply/src/pages/Dashboard.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/Dashboard.tsx
@@ -253,7 +253,7 @@ const Dashboard = () => {
     return (
       <Layout>
         <div className="flex items-center justify-center h-64">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
         </div>
       </Layout>
     );

--- a/application/foodtrace-ledger-supply/src/pages/Index.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/Index.tsx
@@ -23,8 +23,8 @@ const Index = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-rose-50 via-pink-50 to-rose-100">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 via-emerald-50 to-green-100">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     );
   }

--- a/application/foodtrace-ledger-supply/src/pages/Login.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/Login.tsx
@@ -78,7 +78,7 @@ const Login = () => {
       await login(username, password);
       toast({
         title: "Login successful",
-        description: "Welcome to StrawberryChain!",
+        description: "Welcome to FoodTraceChain!",
       });
     } catch (error) {
       toast({
@@ -92,16 +92,16 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-rose-50 via-pink-50 to-rose-100 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-green-100 flex items-center justify-center p-4">
       <div className="w-full max-w-4xl grid md:grid-cols-2 gap-8 items-center">
         {/* Left side - Branding */}
         <div className="text-center md:text-left space-y-6">
           <div className="flex items-center justify-center md:justify-start space-x-3">
-            <div className="h-12 w-12 bg-gradient-to-r from-pink-500 to-rose-600 rounded-xl flex items-center justify-center">
-              <span className="text-white text-2xl" role="img" aria-label="strawberry">🍓</span>
+            <div className="h-12 w-12 bg-gradient-to-r from-green-500 to-emerald-600 rounded-xl flex items-center justify-center">
+              <span className="text-white text-2xl" role="img" aria-label="leaf">🌱</span>
             </div>
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-pink-600 to-rose-600 bg-clip-text text-transparent">
-              StrawberryChain
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
+              FoodTraceChain
             </h1>
           </div>
           
@@ -109,7 +109,7 @@ const Login = () => {
             <h2 className="text-4xl font-bold text-gray-900">
               Farm to Table
               <br />
-              <span className="text-pink-600">Transparency</span>
+              <span className="text-green-600">Transparency</span>
             </h2>
             <p className="text-lg text-gray-600 max-w-md">
               Track your food's journey through the supply chain with blockchain-powered transparency.
@@ -118,7 +118,7 @@ const Login = () => {
 
           <div className="grid grid-cols-2 md:grid-cols-1 gap-4 max-w-md mx-auto md:mx-0">
             <div className="flex items-center space-x-3 p-3 bg-white/60 rounded-lg">
-              <Leaf className="h-5 w-5 text-pink-600" />
+              <Leaf className="h-5 w-5 text-green-600" />
               <span className="text-sm font-medium text-gray-700">Farm Origins</span>
             </div>
             <div className="flex items-center space-x-3 p-3 bg-white/60 rounded-lg">
@@ -154,7 +154,7 @@ const Login = () => {
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   required
-                  className="border-pink-200 focus:border-pink-500"
+                  className="border-green-200 focus:border-green-500"
                   placeholder="Enter your username"
                 />
               </div>
@@ -166,13 +166,13 @@ const Login = () => {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
-                  className="border-pink-200 focus:border-pink-500"
+                  className="border-green-200 focus:border-green-500"
                   placeholder="Enter your password"
                 />
               </div>
               <Button
                 type="submit"
-                className="w-full bg-gradient-to-r from-pink-500 to-rose-600 hover:from-pink-600 hover:to-rose-700 text-white"
+                className="w-full bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white"
                 disabled={loading}
               >
                 {loading ? 'Signing in...' : 'Sign In'}
@@ -203,7 +203,7 @@ const Login = () => {
             <div className="mt-6 text-center">
               <p className="text-sm text-gray-600">Demo Credentials Available</p>
               <div className="mt-2 flex items-center justify-center space-x-2">
-                <ShieldCheck className="h-4 w-4 text-pink-600" />
+                <ShieldCheck className="h-4 w-4 text-green-600" />
                 <span className="text-xs text-gray-500">Blockchain Secured</span>
               </div>
             </div>

--- a/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/PublicTracker.tsx
@@ -141,18 +141,18 @@ const PublicTracker = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-rose-50 via-pink-50 to-rose-100">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-emerald-50 to-green-100">
       {/* Header */}
-      <div className="bg-white/80 backdrop-blur-sm border-b border-rose-200">
+      <div className="bg-white/80 backdrop-blur-sm border-b border-green-200">
         <div className="max-w-6xl mx-auto px-4 py-6">
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center space-x-3">
-              <div className="h-10 w-10 bg-gradient-to-r from-pink-500 to-rose-600 rounded-xl flex items-center justify-center">
+              <div className="h-10 w-10 bg-gradient-to-r from-green-500 to-emerald-600 rounded-xl flex items-center justify-center">
                 <QrCode className="h-6 w-6 text-white" />
               </div>
               <div>
-                <h1 className="text-3xl font-bold bg-gradient-to-r from-pink-600 to-rose-600 bg-clip-text text-transparent">
-                  StrawberryChain Tracker
+                <h1 className="text-3xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
+                  FoodTraceChain Tracker
                 </h1>
                 <p className="text-gray-600">Track your food's journey from farm to table</p>
               </div>
@@ -178,12 +178,12 @@ const PublicTracker = () => {
               value={shipmentId}
               onChange={(e) => setShipmentId(e.target.value)}
               onKeyPress={handleKeyPress}
-              className="border-pink-200 focus:border-pink-500"
+              className="border-green-200 focus:border-green-500"
             />
             <Button 
               onClick={handleSearch}
               disabled={loading}
-              className="bg-pink-600 hover:bg-rose-700"
+              className="bg-green-600 hover:bg-emerald-700"
             >
               {loading ? (
                 <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
@@ -219,7 +219,7 @@ const PublicTracker = () => {
               </p>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-2xl mx-auto">
                 <div className="text-center">
-                  <Leaf className="h-8 w-8 mx-auto text-pink-600 mb-2" />
+                    <Leaf className="h-8 w-8 mx-auto text-green-600 mb-2" />
                   <span className="text-sm font-medium text-gray-700">Farm Origins</span>
                 </div>
                 <div className="text-center">
@@ -338,7 +338,7 @@ const PublicTracker = () => {
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2">
-                    <Leaf className="h-5 w-5 text-pink-600" />
+                    <Leaf className="h-5 w-5 text-green-600" />
                     <span>Farm Origins</span>
                   </CardTitle>
                 </CardHeader>
@@ -516,7 +516,7 @@ const PublicTracker = () => {
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2">
-                    <ShieldCheck className="h-5 w-5 text-pink-600" />
+                    <ShieldCheck className="h-5 w-5 text-green-600" />
                     <span>Certifications</span>
                   </CardTitle>
                 </CardHeader>
@@ -543,13 +543,13 @@ const PublicTracker = () => {
             )}
 
             {/* Blockchain Security Notice */}
-            <Card className="border-rose-200 bg-rose-50">
+            <Card className="border-green-200 bg-green-50">
               <CardContent className="pt-6">
                 <div className="flex items-center space-x-3">
-                  <ShieldCheck className="h-6 w-6 text-pink-600" />
+                  <ShieldCheck className="h-6 w-6 text-green-600" />
                   <div>
-                    <h3 className="font-medium text-rose-900">Blockchain Verified</h3>
-                    <p className="text-sm text-rose-700">
+                    <h3 className="font-medium text-green-900">Blockchain Verified</h3>
+                    <p className="text-sm text-green-700">
                       This information is secured and verified on the blockchain, ensuring authenticity and preventing tampering.
                     </p>
                   </div>

--- a/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/ShipmentDetails.tsx
@@ -200,7 +200,7 @@ const ShipmentDetails = () => {
     return (
       <Layout>
         <div className="flex items-center justify-center h-64">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-pink-600"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
         </div>
       </Layout>
     );


### PR DESCRIPTION
## Summary
- Rebranded frontend from StrawberryChain to FoodTraceChain with leaf icon and green palette
- Updated login and public tracker pages to drop strawberry references and use neutral organic-food styling
- Replaced demo shipment data with generic organic produce details and adjusted components to match new theme

## Testing
- `npm test` *(fails: Missing script "test"; no test suite)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68affc769a2c832d91907b51e1e8e947