### PR TITLE
Normalize API base URL handling

### DIFF
--- a/application/foodtrace-ledger-supply/README.md
+++ b/application/foodtrace-ledger-supply/README.md
@@ -64,6 +64,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment configuration
+
+Create a `.env` file in `application/foodtrace-ledger-supply` and ensure the API base URL includes the protocol (for example `https://strawbchain-production.up.railway.app`). The frontend will refuse to start if the value is missing or malformed.
+
+```
+VITE_API_BASE_URL=https://strawbchain-production.up.railway.app
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/bb5dfebf-3577-4332-8f42-20a3b1d0d6f0) and click on Share -> Publish.

--- a/application/foodtrace-ledger-supply/src/pages/Login.tsx
+++ b/application/foodtrace-ledger-supply/src/pages/Login.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Leaf, TruckIcon, Building, ShieldCheck, Package } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import { API_BASE_URL } from '@/services/api';
 
 const Login = () => {
   const [username, setUsername] = useState('');
@@ -19,8 +20,6 @@ const Login = () => {
   const { login } = useAuth();
   const { toast } = useToast();
   const [demoRole, setDemoRole] = useState('farmer');
-
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   const demoUsers: Record<string, { username: string; password: string; chaincode_alias: string; role: string }> = {
     farmer: { username: 'testf1', password: 'testf1', chaincode_alias: 'DemoFarmer1', role: 'farmer' },

--- a/application/foodtrace-ledger-supply/src/services/api.ts
+++ b/application/foodtrace-ledger-supply/src/services/api.ts
@@ -6,7 +6,35 @@
 import { useAuth } from '@/contexts/AuthContext';
 
 // Update this to point to your local backend server
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const normalizeBaseUrl = (rawValue?: string) => {
+  if (!rawValue) {
+    throw new Error('VITE_API_BASE_URL is not defined.');
+  }
+
+  const trimmedValue = rawValue.trim();
+
+  if (!trimmedValue) {
+    throw new Error('VITE_API_BASE_URL is empty.');
+  }
+
+  const valueWithScheme = /^https?:\/\//i.test(trimmedValue)
+    ? trimmedValue
+    : `https://${trimmedValue}`;
+
+  // Remove trailing slashes to keep endpoint concatenation predictable
+  const normalizedValue = valueWithScheme.replace(/\/+$/, '');
+
+  try {
+    // Throws if the URL is invalid
+    new URL(normalizedValue);
+  } catch (error) {
+    throw new Error(`VITE_API_BASE_URL is not a valid URL: ${trimmedValue}`);
+  }
+
+  return normalizedValue;
+};
+
+export const API_BASE_URL = normalizeBaseUrl(import.meta.env.VITE_API_BASE_URL);
 
 interface ApiResponse<T> {
   data?: T;


### PR DESCRIPTION
## Summary
- validate and normalize the API client base URL before issuing requests
- reuse the normalized base URL in the login page demo account helpers
- document the requirement for `VITE_API_BASE_URL` to include the protocol

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8410f5f3c832d8fc7de4b4abb9c10