### PR TITLE
Configure CORS origins via environment variable

### DIFF
--- a/application/server/server.js
+++ b/application/server/server.js
@@ -20,8 +20,22 @@ require('dotenv').config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+const defaultAllowedOrigins = [
+  'http://localhost:3000',
+  'http://localhost:8080',
+  'http://localhost:3001',
+  'https://strawbchain-k47hg0wq3-m-tameems-projects.vercel.app',
+];
+
+const configuredOrigins = (process.env.CORS_ORIGIN || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const allowedOrigins = configuredOrigins.length > 0 ? configuredOrigins : defaultAllowedOrigins;
+
 const corsOptions = {
-  origin: ['http://localhost:3000', 'http://localhost:8080', 'http://localhost:3001'], // include all frontend origins
+  origin: allowedOrigins,
   credentials: true,
 };
 

--- a/env-example.txt
+++ b/env-example.txt
@@ -20,7 +20,8 @@ RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 
 # CORS Configuration
-CORS_ORIGIN=http://localhost:3000
+# Comma-separated list of allowed origins for CORS requests
+CORS_ORIGIN=http://localhost:3000,http://localhost:8080,http://localhost:3001,https://strawbchain-k47hg0wq3-m-tameems-projects.vercel.app
 
 # Logging
 LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- configure the Express server to derive allowed CORS origins from environment configuration with sensible defaults
- document the full list of local and production origins in the environment example file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d841101b14832d87e4cd04e5effa97