### PR TITLE
Allow production frontend origin for CORS

### DIFF
--- a/application/server/server.js
+++ b/application/server/server.js
@@ -25,6 +25,8 @@ const defaultAllowedOrigins = [
   'http://localhost:8080',
   'http://localhost:3001',
   'https://strawbchain-k47hg0wq3-m-tameems-projects.vercel.app',
+  'https://strawbchain.vercel.app',
+  'https://www.strawbchain.vercel.app',
 ];
 
 const configuredOrigins = (process.env.CORS_ORIGIN || '')

--- a/env-example.txt
+++ b/env-example.txt
@@ -21,7 +21,7 @@ RATE_LIMIT_MAX_REQUESTS=100
 
 # CORS Configuration
 # Comma-separated list of allowed origins for CORS requests
-CORS_ORIGIN=http://localhost:3000,http://localhost:8080,http://localhost:3001,https://strawbchain-k47hg0wq3-m-tameems-projects.vercel.app
+CORS_ORIGIN=http://localhost:3000,http://localhost:8080,http://localhost:3001,https://strawbchain-k47hg0wq3-m-tameems-projects.vercel.app,https://strawbchain.vercel.app,https://www.strawbchain.vercel.app
 
 # Logging
 LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- add the deployed Vercel domain to the server's default CORS allowlist
- document the new allowed origins in the example environment file so production can mirror the configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d847445454832d80879024bd9f3a6b